### PR TITLE
fix(driver): add liveness watchdog to auto-recover a wedged camera

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -196,6 +196,19 @@ class OBCameraNode {
     fps_delay_status_depth_->fillDepthStatus(status_msg);
   }
 
+  // Seconds since the most recent frame set was received, for the driver's
+  // frame-stall watchdog. Returns -1.0 if no frame has arrived yet. Lock-free.
+  double getSecondsSinceLastFrame() const {
+    int64_t last_ns = last_frameset_time_ns_.load(std::memory_order_relaxed);
+    if (last_ns == 0) {
+      return -1.0;
+    }
+    int64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         std::chrono::steady_clock::now().time_since_epoch())
+                         .count();
+    return static_cast<double>(now_ns - last_ns) / 1e9;
+  }
+
   bool checkUserCalibrationReady() {
     static bool first_check = true;
     if (first_check) {
@@ -761,6 +774,9 @@ class OBCameraNode {
   OBStreamType align_target_stream_ = OB_STREAM_COLOR;
   bool retry_on_usb3_detection_failure_ = false;
   std::atomic_bool is_camera_node_initialized_{false};
+  // steady_clock nanoseconds of the last received frame set (0 = none yet);
+  // read by the driver's frame-stall watchdog via getSecondsSinceLastFrame().
+  std::atomic<int64_t> last_frameset_time_ns_{0};
   int laser_energy_level_ = -1;
   ob::PointCloudFilter depth_point_cloud_filter_;
   ob::PointCloudFilter color_point_cloud_filter_;

--- a/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node_driver.h
@@ -69,6 +69,12 @@ class OBCameraNodeDriver : public rclcpp::Node {
 
   void checkConnectTimer();
 
+  // Liveness-watchdog recovery: force-terminate this process so the launch
+  // container (respawn=True) reloads only this camera. Must NOT use
+  // rclcpp::shutdown() — the query/reset threads may be blocked in
+  // uninterruptible SDK calls, deadlocking the destructor's thread joins.
+  [[noreturn]] void recoverAndExit(const std::string& reason);
+
   void queryDevice();
 
   void resetDevice();
@@ -129,6 +135,16 @@ class OBCameraNodeDriver : public rclcpp::Node {
   std::string net_device_ip_;
   int net_device_port_ = 0;
   int connection_delay_ = 100;
+  // Liveness-watchdog tuning (driven by checkConnectTimer at 1 Hz).
+  // <= 0 disables the corresponding check.
+  double connection_timeout_s_ = 30.0;   // max time disconnected before recovery
+  double frame_stall_timeout_s_ = 10.0;  // max no-frame gap after a healthy start
+  // Anchor for the connection-timeout grace; reset on every connected->disconnected
+  // edge so a runtime drop gets the same window as startup (lets the driver's own
+  // reconnect logic try first before we force a respawn).
+  std::chrono::steady_clock::time_point not_connected_since_;
+  std::chrono::steady_clock::time_point device_connected_time_;
+  bool was_connected_ = false;  // tracks connected-state edges for the grace windows
   bool enable_sync_host_time_ = true;
   std::chrono::milliseconds time_sync_period_{6000};
   std::string preset_firmware_path_;

--- a/orbbec_camera/src/ob_camera_node.cpp
+++ b/orbbec_camera/src/ob_camera_node.cpp
@@ -2852,6 +2852,11 @@ void OBCameraNode::onNewFrameSetCallback(std::shared_ptr<ob::FrameSet> frame_set
   if (frame_set == nullptr) {
     return;
   }
+  // Stamp frame liveness for the driver's frame-stall watchdog.
+  last_frameset_time_ns_.store(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                   std::chrono::steady_clock::now().time_since_epoch())
+                                   .count(),
+                               std::memory_order_relaxed);
   try {
     if (!tf_published_) {
       publishStaticTransforms();

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -23,6 +23,8 @@
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <csignal>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <filesystem>
@@ -226,6 +228,9 @@ void OBCameraNodeDriver::init() {
 
   device_type_ = declare_parameter<std::string>("device_type", "camera");
   connection_delay_ = static_cast<int>(declare_parameter<int>("connection_delay", 100));
+  connection_timeout_s_ = declare_parameter<double>("connection_timeout_s", connection_timeout_s_);
+  frame_stall_timeout_s_ =
+      declare_parameter<double>("frame_stall_timeout_s", frame_stall_timeout_s_);
   enable_sync_host_time_ = declare_parameter<bool>("enable_sync_host_time", true);
   double time_sync_period = declare_parameter<double>("time_sync_period", 60.0);
   time_sync_period_ = std::chrono::milliseconds((int)(time_sync_period * 1000));
@@ -258,6 +263,8 @@ void OBCameraNodeDriver::init() {
   orb_device_lock_ = (pthread_mutex_t *)orb_device_lock_shm_addr_;
   pthread_mutex_init(orb_device_lock_, &orb_device_lock_attr_);
   is_alive_.store(true);
+  // Anchor for the connection-timeout watchdog (see checkConnectTimer).
+  not_connected_since_ = std::chrono::steady_clock::now();
   // Initialize the reset device completion time to allow immediate device connection on startup
   last_reset_device_completion_time_ = std::chrono::steady_clock::now() - std::chrono::seconds(10);
   parameters_ = std::make_shared<Parameters>(this);
@@ -395,13 +402,69 @@ OBLogSeverity OBCameraNodeDriver::obLogSeverityFromString(const std::string_view
 }
 
 void OBCameraNodeDriver::checkConnectTimer() {
+  const auto now = std::chrono::steady_clock::now();
   if (!device_connected_.load()) {
     RCLCPP_DEBUG_STREAM(logger_,
                         "checkConnectTimer: device " << serial_number_ << " not connected");
+    // On a connected->disconnected edge, restart the grace window so a runtime
+    // drop gets the driver's own reconnect logic a chance before we force a respawn.
+    if (was_connected_) {
+      not_connected_since_ = now;
+      was_connected_ = false;
+    }
+    // Connection-timeout watchdog: queryDevice() can block forever in an
+    // uninterruptible SDK enumeration call (ctx_->queryDeviceList()) when the USB
+    // endpoint is left in a bad state, so the device never connects and nothing
+    // recovers (respawn only fires on process death). Force a process exit so the
+    // launch container reloads this camera.
+    if (connection_timeout_s_ > 0.0) {
+      const double not_connected_s =
+          std::chrono::duration<double>(now - not_connected_since_).count();
+      if (not_connected_s > connection_timeout_s_) {
+        recoverAndExit("device " + serial_number_ + " failed to connect within " +
+                       std::to_string(connection_timeout_s_) +
+                       "s (likely wedged USB enumeration)");
+      }
+    }
     return;
-  } else if (!ob_camera_node_ && !ob_lidar_node_) {
-    device_connected_.store(false);
   }
+  if (!ob_camera_node_ && !ob_lidar_node_) {
+    device_connected_.store(false);
+    return;
+  }
+  // Mark the (re)connection edge so the frame-stall grace is measured from here.
+  if (!was_connected_) {
+    was_connected_ = true;
+    device_connected_time_ = now;
+  }
+  // Frame-stall watchdog (camera only): a connected device that stops delivering
+  // frames is equally unrecoverable in-process. Until the first frame arrives the
+  // stall is measured from the connection edge.
+  if (frame_stall_timeout_s_ > 0.0 && device_type_ == "camera" && ob_camera_node_) {
+    const double frame_age_s = ob_camera_node_->getSecondsSinceLastFrame();
+    const double stall_s =
+        (frame_age_s < 0.0)
+            ? std::chrono::duration<double>(now - device_connected_time_).count()
+            : frame_age_s;
+    if (stall_s > frame_stall_timeout_s_) {
+      recoverAndExit("device " + serial_number_ + " connected but produced no frames for " +
+                     std::to_string(stall_s) + "s");
+    }
+  }
+}
+
+void OBCameraNodeDriver::recoverAndExit(const std::string &reason) {
+  RCLCPP_FATAL_STREAM(logger_, "Camera liveness watchdog: " << reason
+                                                            << ". Forcing process exit so the "
+                                                               "launch container respawns it.");
+  // Flush logs/streams before bypassing normal teardown. We must hard-exit rather
+  // than rclcpp::shutdown(): the query/reset threads may be blocked in
+  // uninterruptible SDK calls, so the destructor's joins (query_thread_->join())
+  // would deadlock. The launch container's respawn=True reloads only this camera.
+  // Follow-up (see plan/TODO): issue a USB reset of the device here first to break
+  // the alternate-restart toggle so the respawn reconnects on the first cycle.
+  std::fflush(nullptr);
+  std::_Exit(EXIT_FAILURE);
 }
 
 void OBCameraNodeDriver::queryDevice() {


### PR DESCRIPTION
OBCameraNodeDriver::queryDevice() calls ctx_->queryDeviceList(), a blocking libuvc enumeration call with no timeout that hangs forever when the camera's USB endpoint is left in a bad state (Jetson USB-stack enumeration corruption; also reported upstream as orbbec / OrbbecSDK_ROS2 issue 164). Nothing recovered it: the launch container's respawn only fires on process death (the container stays alive while the loaded component is wedged), and a clean unload/reload deadlocks on the destructor's query_thread_->join().

Extend the existing 1 Hz checkConnectTimer() (runs on the executor thread, not the wedged query thread) with a liveness watchdog:
- connection_timeout_s (default 30s): device never reaches device_connected_.
- frame_stall_timeout_s (default 10s): connected camera stops delivering frames (tracked via OBCameraNode::getSecondsSinceLastFrame()/last_frameset_time_ns_). On breach, recoverAndExit() RCLCPP_FATALs and std::_Exit()s the process so the launch container (respawn=True) reloads only this camera. A hard exit is mandatory: rclcpp::shutdown() would hit the same destructor join-deadlock. A connected->disconnected edge restarts the connection grace so the driver's own reconnect logic gets a chance before a forced respawn.

WR patch on top of upstream v2.6.3.